### PR TITLE
Changed UPROPERTIES from raw pointers to TObjectPtr

### DIFF
--- a/Source/ThumbnailGenerator/Private/ThumbnailGenerator.cpp
+++ b/Source/ThumbnailGenerator/Private/ThumbnailGenerator.cpp
@@ -769,7 +769,7 @@ UTexture2D* FThumbnailGenerator::CaptureThumbnail(const FThumbnailSettings& Thum
 
 		const static auto CalcActorLocalThumbnailBounds = [](AActor* InActor, const FThumbnailSettings& InThumbnailSettings, bool bDrawDebug)->FBox
 		{
-			const static TFunction<bool(UActorComponent*, const TSet<UClass*>&)> IsBlacklisted = [](UActorComponent* InComponent, const TSet<UClass*>& Blacklist)->bool
+			const static TFunction<bool(UActorComponent*, const TSet<TObjectPtr<UClass>>&)> IsBlacklisted = [](UActorComponent* InComponent, const TSet<TObjectPtr<UClass>>& Blacklist)->bool
 			{
 				for (UClass* BlacklistedClass : Blacklist)
 				{

--- a/Source/ThumbnailGenerator/Private/ThumbnailScene/ThumbnailBackgroundScene.h
+++ b/Source/ThumbnailGenerator/Private/ThumbnailScene/ThumbnailBackgroundScene.h
@@ -13,7 +13,7 @@ class UThumbnailBackgroundLevelStreamingFixer : public UObject
 private:
 	
 	UPROPERTY()
-	class ULevelStreaming* LevelStreaming;
+	TObjectPtr<class ULevelStreaming> LevelStreaming;
 
 	int32 InstanceID;
 

--- a/Source/ThumbnailGenerator/Public/ThumbnailGeneratorSettings.h
+++ b/Source/ThumbnailGenerator/Public/ThumbnailGeneratorSettings.h
@@ -302,7 +302,7 @@ public:
 
 	// Components of this type will be ignored when calculating the actor bounding box for framing (Ignored when using custom camera transform)
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Thumbnail Actor", meta=(EditCondition = "bOverride_ComponentBoundsBlacklist"))
-	TSet<UClass*> ComponentBoundsBlacklist;
+	TSet<TObjectPtr<UClass>> ComponentBoundsBlacklist;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Thumbnail Actor", meta=(EditCondition = "bOverride_bIncludeHiddenComponentsInBounds"))
 	bool bIncludeHiddenComponentsInBounds;
@@ -418,7 +418,7 @@ class THUMBNAILGENERATOR_API UThumbnailGeneratorSettings : public UObject
 	GENERATED_BODY()
 private:
 	UPROPERTY()
-	TArray<UObject*> AssetRefs;
+	TArray<TObjectPtr<UObject>> AssetRefs;
 
 public:
 


### PR DESCRIPTION
Plugin currently fails to compile with `NativePointerMemberBehaviorOverride = PointerMemberBehavior.Disallow;`. This PR fixes that.